### PR TITLE
Use aws-sdk V3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "aws-sdk", "~> 2.2"

--- a/fluent-plugin-cloudwatch-put.gemspec
+++ b/fluent-plugin-cloudwatch-put.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr"
 
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
-  spec.add_runtime_dependency "aws-sdk", ">= 2"
+  spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1"
 end

--- a/lib/fluent/plugin/out_cloudwatch_put.rb
+++ b/lib/fluent/plugin/out_cloudwatch_put.rb
@@ -1,10 +1,5 @@
 require "fluent/plugin/output"
-
-begin
-  require "aws-sdk-cloudwatch"
-rescue LoadError
-  require "aws-sdk"
-end
+require "aws-sdk-cloudwatch"
 
 module Fluent
   module Plugin


### PR DESCRIPTION
I want to use aws-sdk V3 for the same reason I mentioned in https://github.com/reproio/ecs_deploy/pull/34.
I've checked that all classes used in out_cloudwatch_put.rb are loaded as you can see below:

```
% bundle exec irb
irb(main):001:0> require 'aws-sdk-cloudwatch'
=> true
irb(main):002:0> Aws::CloudWatch::Client
=> Aws::CloudWatch::Client
irb(main):003:0> Aws::STS::Client
=> Aws::STS::Client
irb(main):004:0> Aws::AssumeRoleCredentials
=> Aws::AssumeRoleCredentials
irb(main):005:0> Aws::ECSCredentials
=> Aws::ECSCredentials
irb(main):006:0> Aws::InstanceProfileCredentials
=> Aws::InstanceProfileCredentials
irb(main):007:0> Aws::SharedCredentials
=> Aws::SharedCredentials
irb(main):008:0> Aws::ECSCredentials
=> Aws::ECSCredentials
irb(main):009:0> Aws::InstanceProfileCredentials
=> Aws::InstanceProfileCredentials
```