### PR TITLE
If a dimension doesnt have name, filter it out

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_put.rb
+++ b/lib/fluent/plugin/out_cloudwatch_put.rb
@@ -179,7 +179,7 @@ module Fluent
                   name: extract_placeholders(d.name, meta),
                   value: d.key ? record[d.key] : extract_placeholders(d.value, meta),
                 }
-              },
+              }.select { |d| !d[:name].empty? },
               value: v.to_f,
               timestamp: Time.at(timestamp)
             }
@@ -208,7 +208,7 @@ module Fluent
                 name: extract_placeholders(d.name, meta),
                 value: extract_placeholders(d.value, meta),
               }
-            },
+            }.select { |d| !d[:name].empty? },
             statistic_values: {
               sample_count: values.size,
               sum: values.inject(&:+),


### PR DESCRIPTION
Hi,
Filtering out the dimensions not informed allow us to have a config:
```
  <dimensions>
    name ${dimension_name1}
    value ${dimension_value1}
  </dimensions>
  <dimensions>
    name ${dimension_name2}
    value ${dimension_value2}
  </dimensions>
```
And don't inform the second one if we don't need to.
So we can use the same config for different metrics.